### PR TITLE
Faster responses using concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A serverless Discord slash command bot powered by Vercel written in Golang using
 [![Go Report Card](https://goreportcard.com/badge/github.com/wafer-bw/udx-discord-bot)](https://goreportcard.com/report/github.com/wafer-bw/udx-discord-bot)
 ![CodeQL](https://github.com/wafer-bw/udx-discord-bot/workflows/CodeQL/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/wafer-bw/udx-discord-bot/badge.svg)](https://coveralls.io/github/wafer-bw/udx-discord-bot)
+[![Register Discord Slash Commands](https://github.com/wafer-bw/udx-discord-bot/actions/workflows/sync.yml/badge.svg)](https://github.com/wafer-bw/udx-discord-bot/actions/workflows/sync.yml)
 
 ## Getting Started
 

--- a/commands/chstrat/chstrat_test.go
+++ b/commands/chstrat/chstrat_test.go
@@ -40,7 +40,7 @@ func TestChstrat(t *testing.T) {
 	// 	request := &discord.InteractionRequest{
 	// 		Data: &discord.ApplicationCommandInteractionData{
 	// 			Options: []*discord.ApplicationCommandInteractionDataOption{
-	// 				{Name: "symbol", Value: "TSLA"},
+	// 				{Name: "symbol", Value: "SPY"},
 	// 			},
 	// 		},
 	// 	}

--- a/commands/chstrat/chstrat_test.go
+++ b/commands/chstrat/chstrat_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/require"
 	"github.com/wafer-bw/disgoslash/discord"
 	"github.com/wafer-bw/udx-discord-bot/common/config"
@@ -31,25 +30,24 @@ func TestChstratWrapper(t *testing.T) {
 	})
 }
 
-// todo use mocks so it doesnt spam the api
 func TestChstrat(t *testing.T) {
 
-	t.Run("LIVE RUN", func(t *testing.T) {
-		err := godotenv.Load("../../.env")
-		if err != nil {
-			log.Println("Warning: could not load .env file")
-		}
-		request := &discord.InteractionRequest{
-			Data: &discord.ApplicationCommandInteractionData{
-				Options: []*discord.ApplicationCommandInteractionDataOption{
-					{Name: "symbol", Value: "SPY"},
-				},
-			},
-		}
-		response := chstratWrapper(request)
-		require.NotNil(t, response)
-		require.Equal(t, "", response.Data.Content)
-	})
+	// t.Run("LIVE RUN", func(t *testing.T) {
+	// 	err := godotenv.Load("../../.env")
+	// 	if err != nil {
+	// 		log.Println("Warning: could not load .env file")
+	// 	}
+	// 	request := &discord.InteractionRequest{
+	// 		Data: &discord.ApplicationCommandInteractionData{
+	// 			Options: []*discord.ApplicationCommandInteractionDataOption{
+	// 				{Name: "symbol", Value: "TSLA"},
+	// 			},
+	// 		},
+	// 	}
+	// 	response := chstratWrapper(request)
+	// 	require.NotNil(t, response)
+	// 	require.Equal(t, "", response.Data.Content)
+	// })
 
 	// t.Run("success", func(t *testing.T) {
 	// 	now := time.Now()


### PR DESCRIPTION
By switching to goroutines & channels to lookup every option chain within the expirations we need we are able to respond to discord within it's new 3s limit. If we are nearing the limit we can also stop the process early and process only the options we could grab in time.